### PR TITLE
remove assert on NULL != array

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -346,7 +346,7 @@ KatanaArray* katana_new_array(KatanaParser* parser) {
 
 void katana_destroy_array_using_deallocator(KatanaParser* parser,
                           KatanaArrayDeallocator callback, KatanaArray* array) {
-    assert(NULL != array);
+    //assert(NULL != array);
     if ( NULL == array )
         return;
     for (size_t i = 0; i < array->length; ++i) {


### PR DESCRIPTION
// given a style like this: `filter:mask()`
// when a function with no args, the array  arg will be null,  the call stack blows:
`void katana_destroy_function(KatanaParser* parser, KatanaValueFunction* e)                                                      x
katana_destroy_array(parser, katana_destroy_value, e->args);`
using gdb to show arg e :
`(gdb) p *e
$42 = {name = 0x84c140 "mask(", args = 0x0}`
